### PR TITLE
前端工作流代码质量改进及新增rollup打包

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+dist
+errorJson.js

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,16 @@
+module.exports = {
+    "env": {
+        "browser": true,
+        "es2021": true,
+        "node": true
+    },
+    "extends": [
+        "eslint:recommended"
+    ],
+    "overrides": [
+    ],
+    "parserOptions": {
+        "ecmaVersion": "latest",
+        "sourceType": "module"
+    },
+}

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npx --no-install commitlint --edit "$1"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npx lint-staged

--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,0 +1,3 @@
+{
+  "*.{js,ts}": "eslint --fix"
+}

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,7 @@
+{
+  "printWidth": 100,
+  "tabWidth": 2,
+  "useTabs": false,
+  "semi": true,
+  "arrowParens": "avoid"
+}

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 ## 安装
 
 ```bash
-$ npm i web-see
+$ npm i -S web-see
 ```
 
 ## Vue

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,1 @@
+module.exports = { extends: ['@commitlint/config-conventional'] };

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "lint-staged": "^13.1.0",
     "prettier": "^2.8.0",
     "rollup": "^2.78.0",
+    "rollup-plugin-uglify": "^6.0.4",
     "webpack": "^4.14.0",
     "webpack-cli": "^3.0.8"
   },

--- a/package.json
+++ b/package.json
@@ -2,9 +2,14 @@
   "name": "web-see",
   "version": "1.0.7",
   "description": "监控SDK，一款自研的前端监控SDK，可用来收集并上报：代码报错、性能数据、用户行为、加载资源、个性化指标等数据",
-  "main": "dist/index.js",
+  "main": "dist/index.cjs.js",
+  "module": "dist/index.esm.js",
   "scripts": {
-    "build": "webpack"
+    "build": "webpack",
+    "build:dev": "rollup -w -c",
+    "build:rollup": "rollup -c",
+    "prepare": "husky install",
+    "commit": "git-cz"
   },
   "files": [
     "dist"
@@ -27,11 +32,28 @@
     "web-vitals": "^3.1.0"
   },
   "devDependencies": {
+    "@commitlint/cli": "^17.3.0",
+    "@commitlint/config-conventional": "^17.3.0",
+    "@rollup/plugin-commonjs": "^23.0.3",
+    "@rollup/plugin-json": "^5.0.2",
+    "@rollup/plugin-node-resolve": "^15.0.1",
+    "commitizen": "^4.2.6",
+    "cz-conventional-changelog": "^3.3.0",
+    "eslint": "^8.29.0",
+    "husky": "^8.0.2",
+    "lint-staged": "^13.1.0",
+    "prettier": "^2.8.0",
+    "rollup": "^2.78.0",
     "webpack": "^4.14.0",
     "webpack-cli": "^3.0.8"
   },
   "repository": {
     "type": "git",
     "url": "git@github.com:xy-sea/web-see.git"
+  },
+  "config": {
+    "commitizen": {
+      "path": "./node_modules/cz-conventional-changelog"
+    }
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,6 +1,7 @@
 import resolve from "@rollup/plugin-node-resolve";
 import commonjs from "@rollup/plugin-commonjs";
 import json from "@rollup/plugin-json";
+import {uglify} from 'rollup-plugin-uglify'
 export default [
   {
     input: "./src/index.js",
@@ -35,7 +36,7 @@ export default [
   },
   {
     input: "src/index.js",
-    plugins: [resolve(), commonjs(), json()],
+    plugins: [uglify(),resolve(), commonjs(), json()],
     output: {
       dir: "dist",
       format: "umd",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,47 @@
+import resolve from "@rollup/plugin-node-resolve";
+import commonjs from "@rollup/plugin-commonjs";
+import json from "@rollup/plugin-json";
+export default [
+  {
+    input: "./src/index.js",
+    output: {
+      dir: "dist",
+      format: "cjs",
+      entryFileNames: "index.cjs.js",
+      sourcemap: true,
+    },
+    plugins: [resolve(), commonjs(), json()],
+  },
+  {
+    input: "./src/index.js",
+    output: {
+      dir: "dist",
+      format: "esm",
+      entryFileNames: "index.esm.js",
+      sourcemap: true,
+    },
+    plugins: [resolve(), commonjs(), json()],
+  },
+  {
+    input: "src/index.js",
+    plugins: [resolve(), commonjs(), json()],
+    output: {
+      dir: "dist",
+      format: "umd",
+      name: "web-see",
+      entryFileNames: "index.js",
+      sourcemap: true,
+    },
+  },
+  {
+    input: "src/index.js",
+    plugins: [resolve(), commonjs(), json()],
+    output: {
+      dir: "dist",
+      format: "umd",
+      name: "web-see",
+      entryFileNames: "index.min.js",
+      sourcemap: true,
+    },
+  },
+];

--- a/test/.eslintrc.js
+++ b/test/.eslintrc.js
@@ -1,14 +1,15 @@
 module.exports = {
   root: true,
   env: {
-    node: true
+    node: true,
   },
-  extends: ['plugin:vue/essential', 'eslint:recommended'],
+  extends: ["plugin:vue/essential", "eslint:recommended"],
   parserOptions: {
-    parser: '@babel/eslint-parser'
+    parser: "@babel/eslint-parser",
+    requireConfigFile: false,
   },
   rules: {
-    'no-console': process.env.NODE_ENV === 'production' ? 'warn' : 'off',
-    'no-debugger': process.env.NODE_ENV === 'production' ? 'warn' : 'off'
-  }
+    "no-console": process.env.NODE_ENV === "production" ? "warn" : "off",
+    "no-debugger": process.env.NODE_ENV === "production" ? "warn" : "off",
+  },
 };


### PR DESCRIPTION
该项目非常优秀,希望能为贵项目锦上添花

- 新增rollup打包
> 目前webpack打包后的产物只有esm, 没有commonjs和umd打包产物.而作为一款优秀的前端监控SDK,参考了[sentry](https://github.com/getsentry/sentry-javascript)、 [monitor](https://github.com/clouDr-f2e/monitor)等优秀开源库,都是基于rollup打包
- 新增命令行
> npm run build:dev  当websee 代码变动后,可实时生成dist产物, 在test项目中直接引用打包后的产物,杜绝打包后的代码与本地调试不同造成的bug

> npm run build:rollup 打包四个产物,esm, commonjs, umd, 压缩umd
- test项目.eslintrc.js中添加一行代码
`requireConfigFile: false; 解决打开文件第一行报红问题`

- 前端工作流代码质量改进
> 作为一款优秀的开源库,使用Eslint + Prettier + Husky + Commitlint+ Lint-staged 规范前端工程代码规范,建议加入到REAMDE中,规范pull request的代码
提交规范
feat 增加新功能
fix 修复问题/BUG
style 代码风格相关无影响运行结果的
perf 优化/性能提升
refactor 重构
revert 撤销修改
test 测试相关
docs 文档/注释
build 对构建系统或者外部依赖项进行了修改
chore 依赖更新/脚手架配置修改等
workflow 工作流改进
ci 持续集成
types 类型定义文件更改
wip 开发中
